### PR TITLE
fix WritePropertyDoubleWritesDoubleValueWithoutQuotationMark test for…

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/JsonWriterTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/JsonWriterTest.cs
@@ -105,7 +105,7 @@
                 const string Name = "name";
                 const double Value = 42.3;
                 new JsonWriter(stringWriter).WriteProperty(Name, Value);
-                Assert.Equal("\"" + Name + "\":" + Value, stringWriter.ToString());
+                Assert.Equal("\"" + Name + "\":" + Value.ToString(CultureInfo.InvariantCulture), stringWriter.ToString());
             }
         }
 


### PR DESCRIPTION
fix WritePropertyDoubleWritesDoubleValueWithoutQuotationMark test for some cultures

Some cultures uses comma as decimal symbol.
Test ignored current culture only for one of parameters.